### PR TITLE
Find Component Usages search field and solution explorer

### DIFF
--- a/BlazmExtension/BlazmExtension/BlazmExtension.csproj
+++ b/BlazmExtension/BlazmExtension/BlazmExtension.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Commands\CreateIsolatedCssCommand.cs" />
     <Compile Include="BlazmExtensionPackage.cs" />
+    <Compile Include="Singletons\ComponentNameProvider.cs" />
     <Compile Include="source.extension.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/BlazmExtension/BlazmExtension/BlazmExtension.csproj
+++ b/BlazmExtension/BlazmExtension/BlazmExtension.csproj
@@ -45,7 +45,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Commands\FindComponentReferencesCommand.cs" />
+    <Compile Include="Commands\FindComponentUsagesSECommand.cs" />
+    <Compile Include="Commands\FindComponentUsagesCommand.cs" />
     <Compile Include="Commands\CreatebUnitTestRazorCommand.cs" />
     <Compile Include="Commands\CreateCodebehindCommand.cs" />
     <Compile Include="Commands\CreatebUnitTestCsCommand.cs" />

--- a/BlazmExtension/BlazmExtension/Commands/FindComponentUsagesCommand.cs
+++ b/BlazmExtension/BlazmExtension/Commands/FindComponentUsagesCommand.cs
@@ -6,8 +6,8 @@ using System.IO;
 
 namespace BlazmExtension
 {
-    [Command(PackageIds.FindComponentReferences)]
-    internal sealed class FindComponentReferencesCommand : BaseCommand<FindComponentReferencesCommand>
+    [Command(PackageIds.FindComponentUsages)]
+    internal sealed class FindComponentUsagesCommand : BaseCommand<FindComponentUsagesCommand>
     {
         protected override Task InitializeCompletedAsync()
         {
@@ -15,7 +15,7 @@ namespace BlazmExtension
             return base.InitializeCompletedAsync();
         }
 
-        public static FindComponentReferencesCommand Instance { get; private set; }
+        public static FindComponentUsagesCommand Instance { get; private set; }
 
         protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
         {

--- a/BlazmExtension/BlazmExtension/Commands/FindComponentUsagesSECommand.cs
+++ b/BlazmExtension/BlazmExtension/Commands/FindComponentUsagesSECommand.cs
@@ -1,0 +1,101 @@
+﻿using EnvDTE;
+using Microsoft.VisualStudio.Shell.Interop;
+using System.Text.RegularExpressions;
+using BlazmExtension.Dialogs.ComponentReferences;
+using System.IO;
+using EnvDTE80;
+
+namespace BlazmExtension
+{
+    [Command(PackageIds.FindComponentUsagesSE)]
+    internal sealed class FindComponentUsagesSECommand : BaseCommand<FindComponentUsagesSECommand>
+    {
+        protected override Task InitializeCompletedAsync()
+        {
+            Command.Supported = false;
+            return base.InitializeCompletedAsync();
+        }
+
+        public static FindComponentUsagesSECommand Instance { get; private set; }
+
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var dte = await Package.GetServiceAsync(typeof(DTE)) as DTE2;
+            UIHierarchy uih = (UIHierarchy)dte.Windows.Item(EnvDTE.Constants.vsWindowKindSolutionExplorer).Object;
+            Array selectedItems = (Array)uih.SelectedItems;
+
+            string fileNameWithoutExtension = null;
+            // Ensure only one item is selected
+            if (selectedItems.Length == 1)
+            {
+                UIHierarchyItem selItem = selectedItems.GetValue(0) as UIHierarchyItem;
+
+                if (selItem.Object is ProjectItem prjItem)
+                {
+                    string filePath = prjItem.Properties.Item("FullPath").Value.ToString();
+
+                    // Check if the file is a Razor file
+                    if (Path.GetExtension(filePath).Equals(".razor", StringComparison.OrdinalIgnoreCase))
+                    {
+                        fileNameWithoutExtension = Path.GetFileNameWithoutExtension(filePath);
+                    }
+                }
+            }
+            else if (selectedItems.Length == 0)
+            {
+                VsShellUtilities.ShowMessageBox(
+                    ServiceProvider.GlobalProvider,
+                    "Error: No files selected.",
+                    "Error",
+                    OLEMSGICON.OLEMSGICON_CRITICAL,
+                    OLEMSGBUTTON.OLEMSGBUTTON_OK,
+                    OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
+                return;
+            }
+            else
+            {
+                VsShellUtilities.ShowMessageBox(
+                    ServiceProvider.GlobalProvider,
+                    "Error: Multiple files selected.",
+                    "Error",
+                    OLEMSGICON.OLEMSGICON_CRITICAL,
+                    OLEMSGBUTTON.OLEMSGBUTTON_OK,
+                    OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(fileNameWithoutExtension))
+            {
+                VsShellUtilities.ShowMessageBox(
+                    ServiceProvider.GlobalProvider,
+                    "Unable to determine the component name.",
+                    "Error",
+                    OLEMSGICON.OLEMSGICON_CRITICAL,
+                    OLEMSGBUTTON.OLEMSGBUTTON_OK,
+                    OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
+                return;
+                return;
+            }
+
+            try
+            {
+                ToolWindowPane window = Package.FindToolWindow(typeof(ComponentReferencesWindow), 0, true);
+                if ((null == window) || (null == window.Frame))
+                {
+                    throw new NotSupportedException("Cannot create tool window");
+                }
+
+                IVsWindowFrame windowFrame = (IVsWindowFrame)window.Frame;
+                var control = (ComponentReferencesControl)window.Content;
+                control.Initialize(fileNameWithoutExtension);
+                Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(windowFrame.Show());
+            }
+            catch (Exception ex)
+            {
+
+            }
+        }
+    }
+}

--- a/BlazmExtension/BlazmExtension/Dialogs/ComponentReferences/ComponentReferencesControl.xaml
+++ b/BlazmExtension/BlazmExtension/Dialogs/ComponentReferences/ComponentReferencesControl.xaml
@@ -8,7 +8,9 @@
              xmlns:avalonedit="http://icsharpcode.net/sharpdevelop/avalonedit"
              xmlns:componentReferences="clr-namespace:BlazmExtension.Dialogs.ComponentReferences"
              mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignHeight="450" d:DesignWidth="800"
+             FocusManager.FocusedElement="{Binding ElementName=PlaceholderTextBlock}"
+             MouseDown="UserControl_MouseDown">
 
     <UserControl.Resources>
         <ResourceDictionary>
@@ -63,16 +65,70 @@
                 <Setter Property="Background" Value="{DynamicResource {x:Static vsShell:VsBrushes.ToolWindowBackgroundKey}}"/>
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static vsShell:VsBrushes.ToolWindowTextKey}}"/>
             </Style>
+
+            <Style x:Key="SearchTextBoxStyle" TargetType="TextBox">
+                <Setter Property="Background" Value="{DynamicResource {x:Static vsShell:VsBrushes.ToolWindowBackgroundKey}}"/>
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static vsShell:VsBrushes.ToolWindowTextKey}}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsShell:VsBrushes.ToolWindowBorderKey}}"/>
+                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="Padding" Value="5"/>
+                <Setter Property="Height" Value="28"/>
+                <Setter Property="FontSize" Value="14"/>
+            </Style>
+
+            <!-- Style for Search Button -->
+            <Style x:Key="SearchButtonStyle" TargetType="Button">
+                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Background" Value="#007ACC"/>
+                <!-- VS Blue -->
+                <Setter Property="Height" Value="28"/>
+                <Setter Property="Width" Value="80"/>
+                <Setter Property="FontSize" Value="14"/>
+                <Setter Property="Margin" Value="10,0,0,0"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="4">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </ResourceDictionary>
 
 
     </UserControl.Resources>
-    <Grid>
+    <Grid PreviewMouseDown="Grid_PreviewMouseDown" >
         <!-- Search and Refresh UI -->
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
+
+        <!-- Search TextBox and Button -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10">
+            <Grid>
+                <TextBox x:Name="ComponentSearchTextBox" 
+                         Width="300" 
+                         Style="{StaticResource SearchTextBoxStyle}"
+                         GotFocus="ComponentSearchTextBox_GotFocus"
+                         LostFocus="ComponentSearchTextBox_LostFocus"
+                         TextChanged="ComponentSearchTextBox_TextChanged"
+                         PreviewKeyDown="ComponentSearchTextBox_PreviewKeyDown" />
+                <TextBlock x:Name="PlaceholderTextBlock" 
+                           IsHitTestVisible="False" 
+                           Text="Enter component name..." 
+                           Foreground="Gray" 
+                           VerticalAlignment="Center" 
+                           Padding="5,0" 
+                           Visibility="Visible" />
+            </Grid>
+            <Button Content="Search" 
+                    Style="{StaticResource SearchButtonStyle}" 
+                    Click="OnSearchButtonClick" />
+        </StackPanel>
 
         <!-- Container for the text -->
         <Border Background="{DynamicResource {x:Static vsShell:VsBrushes.ToolWindowBackgroundKey}}"
@@ -80,7 +136,7 @@
                 BorderThickness="1" 
                 Margin="10" 
                 Padding="5" 
-                Grid.Row="0">
+                Grid.Row="1">
             <TextBlock x:Name="ReferenceTextBlock" 
                        Foreground="{DynamicResource {x:Static vsShell:VsBrushes.ToolWindowTextKey}}" 
                        FontWeight="Bold" 
@@ -94,7 +150,7 @@
                   ScrollViewer.HorizontalScrollBarVisibility="Auto"
                   ScrollViewer.VerticalScrollBarVisibility="Auto"
                   MouseDoubleClick="ComponentReferenceGrid_MouseDoubleClick"
-                  Grid.Row="1">
+                  Grid.Row="2">
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding Preview}" Header="Preview" Width="*" IsReadOnly="True"/>
                 <DataGridTextColumn Binding="{Binding FileName}" Header="File Name" Width="*" IsReadOnly="True"/>

--- a/BlazmExtension/BlazmExtension/ExtensionMethods/EnvDteExtensionMethods.cs
+++ b/BlazmExtension/BlazmExtension/ExtensionMethods/EnvDteExtensionMethods.cs
@@ -1,6 +1,7 @@
 ﻿using EnvDTE;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.IO;
+using BlazmExtension.Singletons;
 using Project = EnvDTE.Project;
 
 namespace BlazmExtension.ExtensionMethods
@@ -16,14 +17,18 @@ namespace BlazmExtension.ExtensionMethods
 
             ThreadHelper.ThrowIfNotOnUIThread();
 
+            var componentNames = new List<string>();
             Projects projects = solution.Projects;
             foreach (Project project in projects)
             {
-                foreach (string file in ProcessProjectForRazorFiles(project))
+                foreach (string fileName in ProcessProjectForRazorFiles(project))
                 {
-                    yield return file;
+                    var componentName = Path.GetFileNameWithoutExtension(fileName);
+                    componentNames.Add(componentName);
+                    yield return fileName;
                 }
             }
+            ComponentNameProvider.SetComponentNames(componentNames);
         }
 
         private static IEnumerable<string> ProcessProjectForRazorFiles(Project project)

--- a/BlazmExtension/BlazmExtension/Singletons/ComponentNameProvider.cs
+++ b/BlazmExtension/BlazmExtension/Singletons/ComponentNameProvider.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace BlazmExtension.Singletons
+{
+    public static class ComponentNameProvider
+    {
+        private static List<string> ComponentNames { get; set; } = new List<string>();
+
+        public static void SetComponentNames(IEnumerable<string> componentNames)
+        {
+            if (componentNames != null)
+            {
+                ComponentNames = componentNames.ToList();
+            }
+        }
+        public static IEnumerable<string> GetComponentNames()
+        {
+            return ComponentNames;
+        }
+    }
+}

--- a/BlazmExtension/BlazmExtension/VSCommandTable.cs
+++ b/BlazmExtension/BlazmExtension/VSCommandTable.cs
@@ -62,6 +62,7 @@ namespace BlazmExtension
         public const int jsIcon = 0x0001;
         public const int razorIcon = 0x0001;
         public const int csIcon = 0x0001;
-        public const int FindComponentReferences = 0x0800;
+        public const int FindComponentUsages = 0x0800;
+        public const int FindComponentUsagesSE = 0x0900;
     }
 }

--- a/BlazmExtension/BlazmExtension/VSCommandTable.vsct
+++ b/BlazmExtension/BlazmExtension/VSCommandTable.vsct
@@ -139,6 +139,15 @@
 					<LocCanonicalName>.BlazmExtension.CreateCodebehind</LocCanonicalName>
 				</Strings>
 			</Button>
+
+			<Button guid="BlazmExtension" id="FindComponentUsagesSE" priority="0x0500" type="Button">
+				<Parent guid="BlazmExtension" id="MyMenuGroup" />
+				<Icon guid="RazorIcons" id="razorIcon" />
+				<Strings>
+					<ButtonText>Find component usages</ButtonText>
+					<LocCanonicalName>.BlazmExtension.FindComponentUsagesSE</LocCanonicalName>
+				</Strings>
+			</Button>
 		</Buttons>
 
 		<Menus>
@@ -181,6 +190,7 @@
 			<IDSymbol name="RoutingWindow" value="0x0600" />
 			<IDSymbol name="SwitchToNestedFile" value="0x0700" />
 			<IDSymbol name="FindComponentUsages" value="0x0800" />
+			<IDSymbol name="FindComponentUsagesSE" value="0x0900" />
 			
 			<IDSymbol name="CreatebUnitTestGroup" value="0x0800" />
 			<IDSymbol name="BlazmExtensionMenuGroup" value="0x1020" />


### PR DESCRIPTION
I added caching of component names whenever `GetAllRazorFiles` is called which is what allowed the suggestion in the search field. It will not provide suggestions for components in other libraries but it's better than nothing. Solves the other 2 bullet points from #6 

![SearchField](https://github.com/EngstromJimmy/Blazm.Extension/assets/84036995/3cfda5e6-6fcb-4bf2-972c-22be17bd93c8)
![Suggestion](https://github.com/EngstromJimmy/Blazm.Extension/assets/84036995/43611e23-c65d-4a4c-86e0-232a2c98229c)
![SolutionExplorer](https://github.com/EngstromJimmy/Blazm.Extension/assets/84036995/4ca6df15-df85-4b2b-b40d-b1c2340812e8)
