### PR TITLE
fix: Component Usages with Blue Theme shows the cells completely black

### DIFF
--- a/BlazmExtension/BlazmExtension/Dialogs/ComponentReferences/ComponentReferencesControl.xaml
+++ b/BlazmExtension/BlazmExtension/Dialogs/ComponentReferences/ComponentReferencesControl.xaml
@@ -49,7 +49,7 @@
 
             <!-- Style for the DataGrid cells -->
             <Style TargetType="DataGridCell">
-                <Setter Property="Background" Value="{DynamicResource {x:Static vsShell:VsBrushes.BackgroundKey}}"/>
+                <Setter Property="Background" Value="{DynamicResource {x:Static vsShell:VsBrushes.WindowKey}}"/>
                 <Setter Property="BorderBrush" Value="Transparent"/>
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static vsShell:VsBrushes.ToolWindowTextKey}}"/>
             </Style>


### PR DESCRIPTION
Before fix Blue Theme:
![image](https://github.com/user-attachments/assets/14b6ee60-41a4-42b9-b8b0-39edf4b48212)

#12 fix: Component Usages with Blue Theme shows the cells completely black

Tested with Themes:
- Blue
![image](https://github.com/user-attachments/assets/6211d728-fe2c-4f2c-a554-d16063d4ae9f)
- Blue Extra Contrast
![image](https://github.com/user-attachments/assets/0a968f1c-540e-45d9-9e21-752c4369fea9)
- Light
![image](https://github.com/user-attachments/assets/57783e36-10f6-498a-9c1d-daaeec17f54a)
- Dark
![image](https://github.com/user-attachments/assets/1f8d7c87-5d59-4c69-ba36-56f34875a004)

I wanted to test with other themes like Marvel or Cyberpunk but they are not available in the debugging VS instance.